### PR TITLE
Enable custom mocks file name

### DIFF
--- a/Pod/Classes/SuperMock.swift
+++ b/Pod/Classes/SuperMock.swift
@@ -27,8 +27,8 @@ public class SuperMock: NSObject {
         NSURLSessionConfiguration.defaultSessionConfiguration().protocolClasses = [SuperMockURLProtocol.self]
         NSURLSession.sharedSession().configuration.protocolClasses?.append(SuperMockURLProtocol)
         
+        SuperMockResponseHelper.mocksFileName  = mocksFile
         SuperMockResponseHelper.bundleForMocks = bundle
-        
     }
     
     class func beginRecording(bundle: NSBundle?, mocksFile: String? = "Mocks.plist", policy: SuperMockResponseHelper.RecordPolicy) {
@@ -36,7 +36,8 @@ public class SuperMock: NSObject {
         NSURLProtocol.registerClass(SuperMockRecordingURLProtocol)
         NSURLSessionConfiguration.defaultSessionConfiguration().protocolClasses = [SuperMockRecordingURLProtocol.self]
         NSURLSession.sharedSession().configuration.protocolClasses?.append(SuperMockRecordingURLProtocol)
-        
+
+        SuperMockResponseHelper.mocksFileName  = mocksFile
         SuperMockResponseHelper.bundleForMocks = bundle
         SuperMockResponseHelper.sharedHelper.recording = true
         

--- a/Pod/Classes/SuperMockResponseHelper.swift
+++ b/Pod/Classes/SuperMockResponseHelper.swift
@@ -22,7 +22,21 @@ class SuperMockResponseHelper: NSObject {
         }
     }
     
+    class var mocksFileName: String? {
+        set {
+            if let fileName = newValue, let url = NSURL(string: fileName) {
+                sharedHelper.mocksFile = url.URLByDeletingPathExtension!.absoluteString
+                return
+            }
+            sharedHelper.mocksFile = ""
+        }
+        get {
+            return sharedHelper.mocksFile
+        }
+    }
+
     let fileManager = NSFileManager.defaultManager()
+    var mocksFile: String?
     var bundle : NSBundle? {
         didSet {
             loadDefinitions()
@@ -60,7 +74,7 @@ class SuperMockResponseHelper: NSObject {
             fatalError("You must provide a bundle via NSBundle(class:) or NSBundle.mainBundle() before continuing.")
         }
         
-        if let definitionsPath = bundle.pathForResource("Mocks", ofType: "plist"),
+        if let definitionsPath = bundle.pathForResource(mocksFile!, ofType: "plist"),
             let definitions = NSDictionary(contentsOfFile: definitionsPath) as? Dictionary<String,AnyObject>,
             let mocks = definitions["mocks"] as? Dictionary<String,AnyObject>,
             let mimes = definitions["mimes"] as? Dictionary<String,String> {
@@ -237,7 +251,7 @@ extension SuperMockResponseHelper {
         
         let paths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true) as NSArray
         let documentsDirectory = paths[0] as? String
-        guard let mockPath = documentsDirectory?.stringByAppendingString("/Mocks.plist"),
+        guard let mockPath = documentsDirectory?.stringByAppendingString("/\(mocksFile!).plist"),
             let bundle = bundle else {
                 return nil
         }


### PR DESCRIPTION
Currently the beginMocking method ignores the mocksFile parameter.

This commit will address the issue by passing this mocksFile down to
the SuperMockResponseHelper.
